### PR TITLE
Fix linux/arm64 build: lock down image to temurin-21-tools-deps-1.12.…

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -1,20 +1,3 @@
 #!/usr/bin/env sh
 
-# used to build for --platform linux/amd64,linux/arm64
-# but started getting this error when running the linux/arm64 one:
-#
-# /usr/local/bin/entrypoint: line 19:     7 Aborted                 "${entrypoint}" "${cmd}" --help > /dev/null 2>&1
-# Launching with Java options -server -Xms1g -Xmx1g -XX:+UseG1GC -XX:MaxGCPauseMillis=50
-#
-# A fatal error has been detected by the Java Runtime Environment:
-#
-#  SIGILL (0x4) at pc=0x0000ffff93c67c5c, pid=32, tid=33
-#
-# JRE version:  (21.0.5+11) (build )
-# Java VM: OpenJDK 64-Bit Server VM (21.0.5+11-LTS, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
-# Problematic frame:
-# j  java.lang.System.registerNatives()V+0 java.base@21.0.5
-#
-# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
-
-docker build --platform linux/amd64 --tag filipesilva/datomic-pro-sqlite:latest image/
+docker build --platform linux/amd64,linux/arm64 --tag filipesilva/datomic-pro-sqlite:latest image/

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -1,11 +1,15 @@
-FROM clojure:temurin-22-tools-deps-bookworm-slim
+# https://github.com/docker-library/repo-info/tree/master/repos/clojure/remote
+FROM clojure:temurin-21-tools-deps-1.12.0.1530-bookworm-slim
 
 RUN apt-get update && apt-get install -y curl unzip && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://datomic-pro-downloads.s3.amazonaws.com/1.0.7260/datomic-pro-1.0.7260.zip \
+# https://docs.datomic.com/setup/pro-setup.html#get-datomic
+ARG DATOMIC_VERSION="1.0.7277"
+RUN curl https://datomic-pro-downloads.s3.amazonaws.com/${DATOMIC_VERSION}/datomic-pro-${DATOMIC_VERSION}.zip \
     -o datomic-pro.zip \
+    && echo "68d86d5d156066d8817f85631b29be075899096492a82e251428f768b96dadcf  datomic-pro.zip" | sha256sum -c - \
     && unzip datomic-pro.zip \
-    && mv datomic-pro-1.0.7260 /usr/datomic-pro \
+    && mv datomic-pro-${DATOMIC_VERSION} /usr/datomic-pro \
     || exit 1
 
 RUN curl -L https://github.com/xerial/sqlite-jdbc/releases/download/3.47.0.0/sqlite-jdbc-3.47.0.0.jar \
@@ -14,7 +18,7 @@ RUN curl -L https://github.com/xerial/sqlite-jdbc/releases/download/3.47.0.0/sql
     && mv sqlite-jdbc-3.47.0.0.jar /usr/datomic-pro/lib \
     || exit 1
 
-FROM clojure:temurin-22-tools-deps-bookworm-slim
+FROM clojure:temurin-21-tools-deps-1.12.0.1530-bookworm-slim
 
 RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Hi @filipesilva 

And thanks for a great project.

I locked down the temurin + tools.deps version and now the container starts again for linux/arm64. I also bumped the Datomic version to `1.0.7277` and added a sha check.

Would you consider accepting this pull request or suggest changes please?

Thanks and kind regards.