### PR TITLE
Add HEALTHCHECK CMD

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -y sqlite3 && rm -rf /var/lib/apt/lists/*
 COPY --from=0 /usr/datomic-pro /usr/datomic-pro
 COPY transactor.properties /usr/datomic-pro/config/
 COPY create-db.bsh /usr/create-db.bsh
+HEALTHCHECK CMD /usr/bin/env sh -c '[ -f "/usr/datomic-pro/db_ready" ]' || exit 1
 COPY start.sh /usr/start.sh
 RUN chmod +x /usr/start.sh
 

--- a/image/create-db.bsh
+++ b/image/create-db.bsh
@@ -10,6 +10,11 @@ for (int i = 0; i < 20; i++) {
         if (Peer.createDatabase(db_uri)) {
             System.out.println("Created database '" + db_name + "'");
         }
+        try {
+            new File("/usr/datomic-pro/db_ready").createNewFile();
+        } catch (Exception e) {
+            System.out.println("Could not create file /usr/datomic-pro/db_ready: " + e.getMessage());
+        }
         System.out.println("Connect using DB URI datomic:sql://" + db_name + "?jdbc:sqlite:<LOCAL/PATH/TO/sqlite.db>");
         System.out.println("  e.g. datomic:sql://app?jdbc:sqlite:./storage/sqlite.db if you mounted ./storage");
         System.exit(0);


### PR DESCRIPTION
Hi again @filipesilva 

Thanks for your timely response on the previous pull request.

This pull request adds a Docker HEALTHCHECK CMD that marks the container as healthy when the database has been created / the script is able to connect to the database. This is useful if you have a container in a docker-compose file that depends on the datomic-pro-sqlite container. That is docker will handle that datomic-pro-sqlite will start first and become healthy, and then the other container can start (and avoid having a retry mechanism for the db connection). 

Hope that you will also accept this pull request.
Kind regards
Ivar Refsdal